### PR TITLE
Prevent subject override with default_i18n_subject

### DIFF
--- a/test/mailer/action_mailer_3/notifier.rb
+++ b/test/mailer/action_mailer_3/notifier.rb
@@ -1,38 +1,44 @@
 # Test mailer for ActionMailer 3
 class Notifier < PostageApp::Mailer
-  
+
   self.append_view_path(File.expand_path('../', __FILE__))
-  
+
   def blank
     # ... nothing to see here
   end
-  
+
   def with_no_content
     mail(headers_hash)
   end
-  
+
+  def with_no_email
+    hash_without_email = headers_hash
+    hash_without_email.delete(:subject)
+    mail(hash_without_email)
+  end
+
   def with_text_only_view
     mail(headers_hash)
   end
-  
+
   def with_html_and_text_views
     mail(headers_hash) do |format|
       format.text
       format.html
     end
   end
-  
+
   def with_simple_view
     mail(headers_hash)
   end
-  
+
   def with_body_and_attachment_as_file
     attachments['sample_file.txt'] = 'File content'
     mail(headers_hash) do |format|
       format.html { render :text => 'manual body text'}
     end
   end
-  
+
   def with_body_and_attachment_as_hash
     attachments['sample_file.txt'] = {
       :content_type => 'text/rich',
@@ -42,16 +48,16 @@ class Notifier < PostageApp::Mailer
       format.html { render :text => 'manual body text'}
     end
   end
-  
+
   def with_custom_postage_variables
     headers['CustomHeader1'] = 'CustomValue1'
     headers 'CustomHeader2' => 'CustomValue2'
-    
+
     postageapp_template   'test-template'
     postageapp_variables  'variable' => 'value'
     postageapp_api_key    'custom_api_key'
     postageapp_uid        'custom_uid'
-    
+
     mail(
       :from     => 'test@test.test',
       :subject  => 'Test Message',
@@ -61,14 +67,14 @@ class Notifier < PostageApp::Mailer
       }
     )
   end
-  
+
 private
-  
+
   def headers_hash(options = {})
     { :from     => 'sender@test.test',
       :subject  => 'Test Message',
       :to       => 'test@test.test'
     }.merge(options)
   end
-  
+
 end

--- a/test/mailer_3_test.rb
+++ b/test/mailer_3_test.rb
@@ -13,6 +13,11 @@ class Mailer3Test < Test::Unit::TestCase
       assert_equal ({}), mail.arguments['content']
     end
 
+    def test_create_with_no_email
+      mail = Notifier.with_no_email
+      assert_equal false, mail.arguments['headers'][:subject].present?
+    end
+
     def test_create_with_simple_view
       mail = Notifier.with_simple_view
       assert_equal 'with layout simple view content', mail.arguments['content']['text/html']


### PR DESCRIPTION
By assigning a blank `subject` to `default_i18n_subject` the postageapp's subject will never be used.
