### PR TITLE
Fixed FileUtils dependency

### DIFF
--- a/lib/postageapp.rb
+++ b/lib/postageapp.rb
@@ -2,6 +2,7 @@ require 'net/http'
 require 'net/https'
 require 'digest'
 require 'logger'
+require 'fileutils'
 
 require 'json'
 require 'base64'


### PR DESCRIPTION
Resolving this
```
$ ruby test.rb
/home/user/.gem/ruby/2.3.0/gems/postageapp-1.2.5/lib/postageapp.rb:54:in `logger': uninitialized constant PostageApp::FileUtils (NameError)
Did you mean?  FileTest
	from /home/alex/.gem/ruby/2.3.0/gems/postageapp-1.2.5/lib/postageapp/request.rb:46:in `send'
	from test.rb:29:in `<main>'
```